### PR TITLE
Add Python 3.12 dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "Python 3",
+	// Using the Dockerfile.build instead of a predefined image
+	"build": {
+		"dockerfile": "../Dockerfile.build",
+		"context": "..",
+		"target": "final"
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance"
+			]
+		}
+	}
+}

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,7 @@
-FROM debian:11-slim AS builder
+FROM python:3.12-slim AS builder
 RUN apt-get update -y
-RUN apt-get install -y python3 python3-pip
+RUN apt-get install -y --no-install-recommends gcc build-essential
+
 
 FROM builder as final
 ENV PYTHONBUFFERED 1

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -4,7 +4,7 @@ RUN apt-get install -y --no-install-recommends gcc build-essential
 
 
 FROM builder as final
-ENV PYTHONBUFFERED 1
+ENV PYTHONBUFFERED=1
 RUN mkdir /tmp/code
 ADD ./ /tmp/code
 WORKDIR /tmp/code

--- a/README.md
+++ b/README.md
@@ -2,8 +2,17 @@
 Reference Algorithms for Volunteer Bathymetric Information processing.
 
 ## Installation
+### Local installation
 
 ```pip install .```
+
+### Running in a VS Code dev container
+You will need docker installed to use the dev container. There is more info
+on the specific prerequisites [here](https://code.visualstudio.com/docs/devcontainers/containers).
+Once you have docker installed, open the project in `vscode` and select "Dev
+Container: Reopen in Container" from the command palette. Once the container is
+built and running, you can open a terminal with access to it in `vscode` and
+your environment will be set up.
 
 ## Usage
 


### PR DESCRIPTION
Have to admit I haven't used dev containers much, but I've wanted to play with them. 

I added a normal preconfigured 3.12.8 container using one of the templates built into vscode's 'create dev container' commands (hence all the extra comments in the file). I then changed the `postCreateCommand` to install all the dependencies and set some git settings (`post-create.sh`).

Curious if someone else can try to spin it up and how it works for them. I was able to run `examples/metadata.py` - the others try to read in data that isn't in this repo. 

![image](https://github.com/user-attachments/assets/f02fc363-1c62-4c92-b4e5-6a868089fa20)
